### PR TITLE
Support custom replacement character

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,17 @@
 PATH
   remote: .
   specs:
-    rejectu (0.0.1)
+    rejectu (0.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    power_assert (0.2.4)
     rake (10.3.2)
     rake-compiler (0.9.2)
       rake
+    test-unit (3.1.4)
+      power_assert
 
 PLATFORMS
   ruby
@@ -16,3 +19,4 @@ PLATFORMS
 DEPENDENCIES
   rake-compiler (~> 0.9)
   rejectu!
+  test-unit (~> 3.1)

--- a/ext/rejectu/rejectu.c
+++ b/ext/rejectu/rejectu.c
@@ -166,36 +166,40 @@ do_scrub(VALUE str, VALUE rplToken)
 }
 
 static VALUE
-scrub_with_token(VALUE self, VALUE str, VALUE rplToken)
+scrub(int argc, VALUE *argv, VALUE self)
 {
-  if (is_valid(self, str) == Qtrue) {
-    return rb_enc_str_new(RSTRING_PTR(str), RSTRING_LEN(str), rb_utf8_encoding());
+  VALUE input, token;
+  rb_scan_args(argc, argv, "11", &input, &token);
+
+  if (is_valid(self, input) == Qtrue) {
+    return input;
   }
-  return do_scrub(str, rplToken);
-}
 
-static VALUE
-scrub(VALUE self, VALUE str)
-{
-  return scrub_with_token(self, str, rb_str_new2("?"));
-}
-
-static VALUE
-scrub_bang_with_token(VALUE self, VALUE str, VALUE rplToken)
-{
-  VALUE repl;
-  if (is_valid(self, str) == Qtrue) {
-    return str;
+  if (token == Qnil) {
+    token = rb_str_new2("?");
   }
-  repl = do_scrub(str, rplToken);
-  if (!NIL_P(repl)) rb_str_replace(str, repl);
-  return str;
+
+  return do_scrub(input, token);
 }
 
 static VALUE
-scrub_bang(VALUE self, VALUE str)
+scrub_bang(int argc, VALUE *argv, VALUE self)
 {
-  return scrub_bang_with_token(self, str, rb_str_new2("?"));
+  VALUE input, token;
+  rb_scan_args(argc, argv, "11", &input, &token);
+
+  if (!is_valid(self, input)) {
+    if (token == Qnil) {
+      token = rb_str_new2("?");
+    }
+
+    VALUE repl = do_scrub(input, token);
+    if (!NIL_P(repl)) {
+      rb_str_replace(input, repl);
+    }
+  }
+
+  return input;
 }
 
 void
@@ -204,10 +208,8 @@ Init_rejectu()
   mRejectu = rb_define_module("Rejectu");
 
   rb_define_singleton_method(mRejectu, "valid?", is_valid, 1);
-  rb_define_singleton_method(mRejectu, "scrub", scrub, 1);
-  rb_define_singleton_method(mRejectu, "scrub!", scrub_bang, 1);
-  rb_define_singleton_method(mRejectu, "scrub_with_token", scrub_with_token, 2);
-  rb_define_singleton_method(mRejectu, "scrub_with_token!", scrub_bang_with_token, 2);
+  rb_define_singleton_method(mRejectu, "scrub", scrub, -1);
+  rb_define_singleton_method(mRejectu, "scrub!", scrub_bang, -1);
 
   idEncoding = rb_intern("encoding");
   idTo_s = rb_intern("to_s");

--- a/ext/rejectu/rejectu.c
+++ b/ext/rejectu/rejectu.c
@@ -208,6 +208,7 @@ Init_rejectu()
 {
   mRejectu = rb_define_module("Rejectu");
   defaultToken = rb_str_new2("?");
+  rb_global_variable(&defaultToken);
 
   rb_define_singleton_method(mRejectu, "valid?", is_valid, 1);
   rb_define_singleton_method(mRejectu, "scrub", scrub, -1);

--- a/ext/rejectu/rejectu.c
+++ b/ext/rejectu/rejectu.c
@@ -125,7 +125,7 @@ is_valid(VALUE self, VALUE str)
 }
 
 static VALUE
-do_scrub(VALUE str)
+do_scrub(VALUE str, char rplToken)
 {
   VALUE out_str;
   unsigned char *p, *end, *out_start, *out;
@@ -151,7 +151,7 @@ do_scrub(VALUE str)
       } else {
         p += 4;
       }
-      *out++ = '?';
+      *out++ = rplToken;
     } else {
       *out++ = *p++;
     }
@@ -170,7 +170,7 @@ scrub(VALUE self, VALUE str)
   if (is_valid(self, str) == Qtrue) {
     return rb_enc_str_new(RSTRING_PTR(str), RSTRING_LEN(str), rb_utf8_encoding());
   }
-  return do_scrub(str);
+  return do_scrub(str, '?');
 }
 
 static VALUE
@@ -180,7 +180,7 @@ scrub_bang(VALUE self, VALUE str)
   if (is_valid(self, str) == Qtrue) {
     return str;
   }
-  repl = do_scrub(str);
+  repl = do_scrub(str, '?');
   if (!NIL_P(repl)) rb_str_replace(str, repl);
   return str;
 }

--- a/ext/rejectu/rejectu.c
+++ b/ext/rejectu/rejectu.c
@@ -7,6 +7,8 @@
 static VALUE mRejectu = Qnil;
 static VALUE idEncoding, idTo_s;
 
+static char *defaultToken = "?";
+
 #ifdef __SSE2__
 static inline int
 has_utf8_supplementary_planes(__m128i v)
@@ -176,7 +178,7 @@ scrub(int argc, VALUE *argv, VALUE self)
   }
 
   if (token == Qnil) {
-    token = rb_str_new2("?");
+    token = rb_str_new2(defaultToken);
   }
 
   return do_scrub(input, token);
@@ -190,7 +192,7 @@ scrub_bang(int argc, VALUE *argv, VALUE self)
 
   if (!is_valid(self, input)) {
     if (token == Qnil) {
-      token = rb_str_new2("?");
+      token = rb_str_new2(defaultToken);
     }
 
     VALUE repl = do_scrub(input, token);

--- a/ext/rejectu/rejectu.c
+++ b/ext/rejectu/rejectu.c
@@ -6,8 +6,7 @@
 
 static VALUE mRejectu = Qnil;
 static VALUE idEncoding, idTo_s;
-
-static char *defaultToken = "?";
+static VALUE defaultToken = Qnil;
 
 #ifdef __SSE2__
 static inline int
@@ -178,7 +177,7 @@ scrub(int argc, VALUE *argv, VALUE self)
   }
 
   if (token == Qnil) {
-    token = rb_str_new2(defaultToken);
+    token = defaultToken;
   }
 
   return do_scrub(input, token);
@@ -192,7 +191,7 @@ scrub_bang(int argc, VALUE *argv, VALUE self)
 
   if (!is_valid(self, input)) {
     if (token == Qnil) {
-      token = rb_str_new2(defaultToken);
+      token = defaultToken;
     }
 
     VALUE repl = do_scrub(input, token);
@@ -208,6 +207,7 @@ void
 Init_rejectu()
 {
   mRejectu = rb_define_module("Rejectu");
+  defaultToken = rb_str_new2("?");
 
   rb_define_singleton_method(mRejectu, "valid?", is_valid, 1);
   rb_define_singleton_method(mRejectu, "scrub", scrub, -1);

--- a/rejectu.gemspec
+++ b/rejectu.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.extensions = ['ext/rejectu/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'test-unit', '~> 3.1'
 end

--- a/test/test_rejectu.rb
+++ b/test/test_rejectu.rb
@@ -77,10 +77,19 @@ class TestRejectu < Test::Unit::TestCase
     assert_equal "? test string", Rejectu.scrub("\xf2\xa4\xb7\xa4 test string")
   end
 
+  def test_scrub_with_token
+    assert_equal ". test string", Rejectu.scrub_with_token("\xf2\xa4\xb7\xa4 test string", ".")
+  end
+
   def test_scrub!
     s = "\xf2\xa4\xb7\xa4 test string"
     assert_equal "? test string", Rejectu.scrub!(s)
     assert_equal "? test string", s
   end
 
+  def test_scrub_with_token!
+    s = "\xf2\xa4\xb7\xa4 test string"
+    assert_equal ". test string", Rejectu.scrub_with_token!(s, ".")
+    assert_equal ". test string", s
+  end
 end

--- a/test/test_rejectu.rb
+++ b/test/test_rejectu.rb
@@ -77,8 +77,8 @@ class TestRejectu < Test::Unit::TestCase
     assert_equal "? test string", Rejectu.scrub("\xf2\xa4\xb7\xa4 test string")
   end
 
-  def test_scrub_with_token
-    assert_equal ". test string", Rejectu.scrub_with_token("\xf2\xa4\xb7\xa4 test string", ".")
+  def test_scrub_with_custom_token
+    assert_equal ". test string", Rejectu.scrub("\xf2\xa4\xb7\xa4 test string", ".")
   end
 
   def test_scrub!
@@ -87,9 +87,9 @@ class TestRejectu < Test::Unit::TestCase
     assert_equal "? test string", s
   end
 
-  def test_scrub_with_token!
+  def test_scrub_with_custom_token!
     s = "\xf2\xa4\xb7\xa4 test string"
-    assert_equal ". test string", Rejectu.scrub_with_token!(s, ".")
+    assert_equal ". test string", Rejectu.scrub!(s, ".")
     assert_equal ". test string", s
   end
 end


### PR DESCRIPTION
@csfrancis 

I've added two new methods to Rejectu that add support for specifying a replacement character to be used instead of the default `?`.

I'm sure there's a way I could do this with var args and use the two existing methods, but I thought I'd get your opinion on the idea first.
